### PR TITLE
Replace deprecated login to avoid warnings

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -26,7 +26,7 @@ class VaultClient(object):
         vault_url = os.environ.get("VAULT_ADDR", DEFAULT_VAULT_ADDR)
         vault_token = self._get_token()
         self.client = hvac.Client(url=vault_url)
-        self.client.auth_github(vault_token)
+        self.client.auth.github.login(token=vault_token)
 
     def _get_token(self):
         vault_token = os.environ.get("VAULT_AUTH_GITHUB_TOKEN")


### PR DESCRIPTION
I've checked this by locally running
```
from vault.vault import VaultClient

vault = VaultClient()
secret = vault.read_secret("secret/some/path")
```
and seen that it is no longer producing deprecation warnings